### PR TITLE
Update r3dnet.h

### DIFF
--- a/code/include/r3dnet.h
+++ b/code/include/r3dnet.h
@@ -42,7 +42,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/stat.h>
-#include <sys/sendfile.h>
 #include <fcntl.h>
 #include <signal.h>
 


### PR DESCRIPTION
sendfile is not actually used, no need to include linux-only header