### PR TITLE
Update main.c

### DIFF
--- a/code/main.c
+++ b/code/main.c
@@ -24,10 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/****************** mtrace and muntrace for debugging purpose *****************/
-#ifdef __linux__
-    #include <mcheck.h>
-#endif
 
 /******************************************************************************/
 #include <config.h>


### PR DESCRIPTION
mcheck.h functionality is not used, no need to include non-standard header

see https://www.gnu.org/software/gnulib/manual/html_node/mcheck_002eh.html re portability problems